### PR TITLE
fix: land review follow-ups missed by PR #6 and #8 merges

### DIFF
--- a/src/components/AppGrid.tsx
+++ b/src/components/AppGrid.tsx
@@ -256,11 +256,20 @@ const AppCard = React.memo(function AppCard({ app, mode, locale, t }: { app: App
 								</div>
 								<span className="mt-0.5 text-[11px] font-medium text-brand-700 dark:text-brand-400">{app.category}</span>
 								<p className="mt-1 text-sm text-gray-500 dark:text-gray-400 line-clamp-1 leading-snug">{app.tagline}</p>
-								{rating !== null && (
+								{(rating !== null || app.downloadsLabel) && (
 									<div className="mt-2 flex items-center gap-2">
-										<div className="flex items-center gap-0.5">{stars}</div>
-										<span className="text-[11px] font-semibold text-gray-400 dark:text-gray-500">{rating}</span>
-										{app.downloadsLabel && <span className="text-[11px] text-gray-400 dark:text-gray-500">&middot; {app.downloadsLabel}</span>}
+										{rating !== null && (
+											<>
+												<div className="flex items-center gap-0.5">{stars}</div>
+												<span className="text-[11px] font-semibold text-gray-400 dark:text-gray-500">{rating}</span>
+											</>
+										)}
+										{app.downloadsLabel && (
+											<span className="text-[11px] text-gray-400 dark:text-gray-500">
+												{rating !== null && "· "}
+												{app.downloadsLabel}
+											</span>
+										)}
 									</div>
 								)}
 							</a>
@@ -377,11 +386,23 @@ const AppCard = React.memo(function AppCard({ app, mode, locale, t }: { app: App
 						<p className="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-snug line-clamp-2">
 							{app.tagline}
 						</p>
-						{rating !== null && (
-							<div className="mt-3 flex items-center gap-2.5" aria-label={`Rating ${rating} out of 5`}>
-								<div className="flex items-center gap-0.5">{stars}</div>
-								<span className="text-[11px] font-semibold text-gray-400 dark:text-gray-500">{rating}</span>
-								{app.downloadsLabel && <span className="text-[11px] text-gray-400 dark:text-gray-500">&middot; {app.downloadsLabel}</span>}
+						{(rating !== null || app.downloadsLabel) && (
+							<div
+								className="mt-3 flex items-center gap-2.5"
+								aria-label={rating !== null ? `Rating ${rating} out of 5` : undefined}
+							>
+								{rating !== null && (
+									<>
+										<div className="flex items-center gap-0.5">{stars}</div>
+										<span className="text-[11px] font-semibold text-gray-400 dark:text-gray-500">{rating}</span>
+									</>
+								)}
+								{app.downloadsLabel && (
+									<span className="text-[11px] text-gray-400 dark:text-gray-500">
+										{rating !== null && "· "}
+										{app.downloadsLabel}
+									</span>
+								)}
 							</div>
 						)}
 					</a>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -83,7 +83,7 @@
     "expirooBadge": "New · Closed beta",
     "expirooTitle": "Meet Expiroo",
     "expirooDeck": "Track expiry dates and your home inventory — works offline, no account needed. Be one of the first testers.",
-    "expirooSecondary": "Learn more",
+    "expirooSecondary": "Learn more about Expiroo",
     "expirooCtaAria": "Join the Expiroo closed beta — opens in a new tab",
     "expirooSecondaryAria": "Learn more about Expiroo"
   },

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -83,7 +83,7 @@
     "expirooBadge": "Nuevo · Beta cerrada",
     "expirooTitle": "Te presentamos Expiroo",
     "expirooDeck": "Controla fechas de caducidad y tu inventario del hogar — funciona sin conexión y sin cuenta. Sé de los primeros en probarla.",
-    "expirooSecondary": "Ver más",
+    "expirooSecondary": "Ver más sobre Expiroo",
     "expirooCtaAria": "Únete a la beta cerrada de Expiroo — se abre en una pestaña nueva",
     "expirooSecondaryAria": "Ver más sobre Expiroo"
   },

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -83,7 +83,7 @@
     "expirooBadge": "Novo · Beta fechado",
     "expirooTitle": "Conheça o Expiroo",
     "expirooDeck": "Acompanhe datas de validade e seu inventário doméstico — funciona offline e sem conta. Seja um dos primeiros a testar.",
-    "expirooSecondary": "Saiba mais",
+    "expirooSecondary": "Saiba mais sobre o Expiroo",
     "expirooCtaAria": "Participe do beta fechado do Expiroo — abre em uma nova aba",
     "expirooSecondaryAria": "Saiba mais sobre o Expiroo"
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -181,7 +181,7 @@ const features = [
 							<span>Join the free beta</span>
 						</a>
 						<a href="/apps/expiroo" class="button w-full min-h-[44px] border border-white/25 text-white hover:bg-white/10 focus:ring-white/70 focus:ring-offset-transparent sm:w-auto" aria-label="Learn more about Expiroo">
-							Learn more
+							Learn more about Expiroo
 						</a>
 					</div>
 				</div>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -22,9 +22,18 @@ const LEGAL_PAGES: Array<{ slug: string; path: string }> = [
 export const GET: APIRoute = async ({ site }) => {
 	const abs = (path: string) => new URL(path, site).href;
 
-	const apps = await getCollection("apps", ({ slug }) => slug.startsWith("en/"));
-	const posts = await getCollection("blog", ({ slug }) => slug.startsWith("en/"));
-	const comparisons = await getCollection("comparisons", ({ slug }) => slug.startsWith("en/"));
+	// Sort deterministically so the emitted /llms.txt is stable across builds
+	// (getCollection traversal order is not guaranteed). Apps/comparisons go
+	// alphabetically by title; posts go newest-first by publish date.
+	const apps = (await getCollection("apps", ({ slug }) => slug.startsWith("en/"))).sort((a, b) =>
+		a.data.title.localeCompare(b.data.title),
+	);
+	const posts = (await getCollection("blog", ({ slug }) => slug.startsWith("en/"))).sort(
+		(a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
+	);
+	const comparisons = (
+		await getCollection("comparisons", ({ slug }) => slug.startsWith("en/"))
+	).sort((a, b) => a.data.title.localeCompare(b.data.title));
 	const legal = await getCollection("legal");
 	const legalBySlug = new Map(legal.map((e) => [e.slug, e]));
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -352,7 +352,7 @@
 
 	/* Beta-join CTA: white-on-orange (distinct from the black-on-orange download CTA) */
 	.button--beta {
-		@apply focus:ring-accent-500 text-white shadow-sm hover:shadow-md;
+		@apply text-white shadow-sm hover:shadow-md;
 		background: var(--color-accent-700);
 	}
 


### PR DESCRIPTION
PRs #6 and #8 were merged with their earlier heads, so two review-fix commits never reached `main`. This PR lands them.

**From PR #6 review (Copilot):**
- Descriptive link text for the Expiroo launch-band CTA ("Learn more about Expiroo") — Lighthouse non-descriptive-link finding.
- Render app download counts **independently of rating** in `AppGrid` (the removed 4.5★ guard was also hiding downloads for apps without a rating).
- Dedupe the beta CTA focus ring (`.button--beta` no longer sets `focus:ring-accent-500`; launch band uses the white ring).

**From PR #8 review (Copilot):**
- Sort `llms.txt` collections (apps/comparisons by title, blog by date) for deterministic output.

Cherry-picked from the original branch heads (5a6a786, 0881e3a). `pnpm check` = baseline only, no new errors.